### PR TITLE
slightly smarter travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,17 +5,31 @@ services:
 
 stages:
   - name: build
+    if: branch != master
+  - name: build-and-push
+    if: branch == master
 
 jobs:
   include:
     - stage: build
       script:
-      - export WORKER_IMAGE=koobz/crusher-server:${TRAVIS_COMMIT:0:8}
-      - export SERVER_IMAGE=koobz/crusher-worker:${TRAVIS_COMMIT:0:8}
+      - export WORKER_IMAGE=koobz/crusher-worker:${TRAVIS_COMMIT:0:8}
       - cd worker
       - docker build -t $WORKER_IMAGE .
-      - cd ../server
+    - script:
+      - export SERVER_IMAGE=koobz/crusher-server:${TRAVIS_COMMIT:0:8}
+      - cd server
       - docker build -t $SERVER_IMAGE .
+    - stage: build-and-push
+      script:
+      - export WORKER_IMAGE=koobz/crusher-worker:${TRAVIS_COMMIT:0:8}
+      - cd worker
+      - docker build -t $WORKER_IMAGE .
       - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
       - docker push $WORKER_IMAGE
+    - script:
+      - export SERVER_IMAGE=koobz/crusher-server:${TRAVIS_COMMIT:0:8}
+      - cd server
+      - docker build -t $SERVER_IMAGE .
+      - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
       - docker push $SERVER_IMAGE


### PR DESCRIPTION
parallelizes the stages and doesn't push unless it's merged to master.
I guess I don't want every branch polluting the dockerhub images.