### PR TITLE
use letsencrypt-generated certificates

### DIFF
--- a/deploy/manifest.yml
+++ b/deploy/manifest.yml
@@ -44,7 +44,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 5
       containers:
-        - image: koobz/crusher-server
+        - image: koobz/crusher-server:9da226c1
           name: crusher-server
 ---
 apiVersion: apps/v1
@@ -69,8 +69,40 @@ spec:
     spec:
       terminationGracePeriodSeconds: 5
       containers:
-        - image: koobz/crusher-worker
+        - image: koobz/crusher-worker:9da226c1
           name: crusher-worker
           env:
             - name: CRUSHER_HOST
               value: http://crusher-server
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: crusher
+  namespace: crusher
+spec:
+  tls:
+  - hosts:
+    - crusher.k8s.koobz.io
+    secretName: crusher-tls
+  rules:
+  - host: crusher.k8s.koobz.io
+    http:
+      paths:
+      - backend:
+          serviceName: crusher-server
+          servicePort: 5000
+---
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: crusher
+  namespace: crusher
+spec:
+  secretName: crusher-tls
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+  - crusher.k8s.koobz.io
+  renewBefore: 720h


### PR DESCRIPTION
I'm running [cert-manager](https://github.com/jetstack/cert-manager) to generate SSL certificates in my cheapo GKE cluster. This PR:

- Adds the Certificate resource to tell cert-manager what kind of cert it needs to provision for me.
- Sets the relevant image sha's to a recent working build.