### PR TITLE
use persistent disk for crusher database

### DIFF
--- a/deploy/base/kustomization.yaml
+++ b/deploy/base/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- manifest.yaml

--- a/deploy/base/manifest.yaml
+++ b/deploy/base/manifest.yaml
@@ -43,9 +43,19 @@ spec:
         component: server
     spec:
       terminationGracePeriodSeconds: 5
+      volumes:
+        - name: crusher-database
+          persistentVolumeClaim:
+            claimName: crusher-database
       containers:
         - image: koobz/crusher-server:9da226c1
           name: crusher-server
+          env:
+          - name: CRUSHER_REPO_PATH
+            value: /data/crusher.db
+          volumeMounts:
+          - mountPath: "/data"
+            name: crusher-database
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -92,17 +102,3 @@ spec:
       - backend:
           serviceName: crusher-server
           servicePort: 5000
----
-apiVersion: certmanager.k8s.io/v1alpha1
-kind: Certificate
-metadata:
-  name: crusher
-  namespace: crusher
-spec:
-  secretName: crusher-tls
-  issuerRef:
-    name: letsencrypt-production
-    kind: ClusterIssuer
-  dnsNames:
-  - crusher.k8s.koobz.io
-  renewBefore: 720h

--- a/dev.sh
+++ b/dev.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
+kubectl config use-context minikube
 source <(minikube docker-env -p minikube)
 skaffold config set --kube-context minikube local-cluster true
+skaffold dev

--- a/server/app.py
+++ b/server/app.py
@@ -84,6 +84,8 @@ PUBLIC_RESULTS_CHANNEL = "campsites"
 #: This should match the name of the application, using a different name
 #: is a from of masquerading and may require additional permissions.
 BOT_NAME = "CrusherScrape"
+#: The path to the watcher database.
+REPO_PATH = os.getenv('CRUSHER_REPO_PATH', '/tmp/crusher.db')
 
 
 class WatchersRepo(object):

--- a/skaffold.yml
+++ b/skaffold.yml
@@ -1,13 +1,13 @@
 apiVersion: skaffold/v1beta11
 kind: Config
 build:
-  local: {}
+  local:
+    push: false
   artifacts:
     - image: koobz/crusher-dev-server
       context: server
     - image: koobz/crusher-dev-worker
       context: worker
 deploy:
-  kubectl:
-    manifests:
-      - deploy/*.yml
+  kustomize:
+    path: deploy/env/dev


### PR DESCRIPTION
Motivation:
- Don't lose watches on reboot.
- Facilitate migrating existing watchers.